### PR TITLE
Add unit tests for model communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,34 @@ agent-team/
 │   ├── tools/         # Agent tools
 │   └── main.py        # Main entry point
 ├── logs/              # Global logs directory
+├── tests/             # Unit tests
 ├── requirements.txt   # Project dependencies
 ├── setup.py           # Package setup
 └── README.md          # Project documentation
 ```
+
+## Testing
+
+The project uses pytest for testing. To run the tests:
+
+```bash
+# Install development dependencies
+pip install -e ".[dev]"
+
+# Run all tests
+pytest
+
+# Run tests with coverage report
+pytest --cov=agent_team
+
+# Skip tests that require actual model communication
+pytest -m "not optional"
+```
+
+The tests include:
+- Unit tests for each agent role (PLANNER, MANAGER, ACTOR, EVALUATOR)
+- Tests that verify model communication works correctly
+- Tests that validate configuration file parsing
 
 ## License
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+
+markers =
+    optional: tests that require access to the actual model and may be skipped in CI

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
 jinja2>=3.0.0
 requests>=2.25.1
 python-dotenv>=0.19.0
+
+# Development dependencies
+pytest>=7.0.0
+pytest-mock>=3.10.0
+pytest-cov>=4.0.0

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,13 @@ setup(
         "requests>=2.25.1",
         "python-dotenv>=0.19.0",
     ],
+    extras_require={
+        "dev": [
+            "pytest>=7.0.0",
+            "pytest-mock>=3.10.0",
+            "pytest-cov>=4.0.0",
+        ]
+    },
     author="DeeNihl",
     author_email="deenihl@github.com",
     description="A bare bones Python autonomous agent project",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the agent team package."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,59 @@
+"""
+Pytest configuration for agent team tests.
+"""
+import os
+import csv
+import pytest
+import tempfile
+from pathlib import Path
+
+
+@pytest.fixture
+def agent_model_props_path():
+    """Get the path to the agent model properties file."""
+    return os.path.join(os.path.dirname(os.path.dirname(__file__)), 
+                        "agent_team", "data", "agent_model_props.csv")
+
+
+@pytest.fixture
+def agent_roles():
+    """Return a list of all agent roles."""
+    return ["PLANNER", "MANAGER", "ACTOR", "EVALUATOR"]
+
+
+@pytest.fixture
+def test_props_file():
+    """Create a temporary props file for testing with valid entries."""
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.csv') as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            "amp_id", "AGENT_ROLE", "model_name", "model_props_args", 
+            "AGENT_ROLE_PROMPT", "TOOL_LIST"
+        ])
+        writer.writerow([
+            "1", "PLANNER", "qwq", "model:qwq:latest,temperature:0.8,num_ctx:32000,api_url:10.0.0.16:11434,api_key:",
+            "You are a planner", ""
+        ])
+        writer.writerow([
+            "2", "MANAGER", "qwq", "model:qwq:latest,temperature:0.7,num_ctx:32000,api_url:10.0.0.16:11434,api_key:",
+            "You are a manager", ""
+        ])
+        writer.writerow([
+            "3", "ACTOR", "gemma", "model:gemma:12b,temperature:0.7,num_ctx:32000,api_url:10.0.0.16:11434,api_key:",
+            "You are an actor", ""
+        ])
+        writer.writerow([
+            "4", "EVALUATOR", "gemma", "model:gemma:12b,temperature:0.3,num_ctx:32000,api_url:10.0.0.16:11434,api_key:",
+            "You are an evaluator", ""
+        ])
+    
+    yield f.name
+    # Clean up the temporary file
+    os.unlink(f.name)
+
+
+@pytest.fixture
+def test_agent_team():
+    """Create an instance of the AgentTeam class."""
+    from agent_team.main import AgentTeam
+    return AgentTeam()

--- a/tests/test_model_communication.py
+++ b/tests/test_model_communication.py
@@ -1,0 +1,161 @@
+"""
+Tests for model communication in the agent team.
+
+These tests verify that the agent team can communicate with each model
+for all agent roles defined in the agent_model_props.csv file.
+"""
+import os
+import csv
+import pytest
+import requests
+from unittest import mock
+
+from agent_team.main import AgentTeam
+
+
+def test_agent_model_props_exists(agent_model_props_path):
+    """Test that the agent model properties file exists."""
+    assert os.path.exists(agent_model_props_path), "Agent model properties file does not exist"
+    
+    # Verify the file has content
+    with open(agent_model_props_path, 'r') as f:
+        content = f.read()
+        assert len(content) > 0, "Agent model properties file is empty"
+        
+    # Verify the file is valid CSV
+    with open(agent_model_props_path, 'r') as f:
+        reader = csv.reader(f)
+        rows = list(reader)
+        assert len(rows) > 1, "Agent model properties file has no data rows"
+        assert len(rows[0]) >= 5, "Agent model properties file has insufficient columns"
+
+
+@pytest.mark.parametrize("agent_role", ["PLANNER", "MANAGER", "ACTOR", "EVALUATOR"])
+def test_parse_model_props(test_agent_team, agent_role, agent_model_props_path):
+    """Test that the agent team can parse model properties for each agent role."""
+    # Load the properties from the file
+    agent_props = None
+    with open(agent_model_props_path, 'r') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if row['AGENT_ROLE'] == agent_role:
+                agent_props = row
+                break
+    
+    assert agent_props is not None, f"No properties found for {agent_role}"
+    
+    # Test parsing model props
+    model_props_args = agent_props.get('model_props_args', '')
+    model_params = test_agent_team._parse_model_props(model_props_args)
+    
+    assert isinstance(model_params, dict), "Model parameters should be a dictionary"
+    
+    # Check that we have the expected properties
+    if 'api_url' in model_props_args:
+        assert 'api_url' in model_params, f"api_url not found in model parameters for {agent_role}"
+    
+    # Make sure model key exists which is needed for ollama
+    if 'model:' in model_props_args:
+        model_keys = [k for k in model_params.keys() if k == 'model']
+        assert len(model_keys) > 0, f"No model specified in model parameters for {agent_role}"
+
+
+class MockResponse:
+    """Mock response for requests."""
+    def __init__(self, json_data, status_code=200):
+        self.json_data = json_data
+        self.status_code = status_code
+        
+    def json(self):
+        """Return the mock JSON data."""
+        return self.json_data
+        
+    def raise_for_status(self):
+        """Raise an exception if the status code indicates an error."""
+        if self.status_code != 200:
+            raise requests.exceptions.HTTPError(f"HTTP Error: {self.status_code}")
+
+
+@pytest.mark.parametrize("agent_role", ["PLANNER", "MANAGER", "ACTOR", "EVALUATOR"])
+def test_model_communication_planner(test_agent_team, agent_role, agent_model_props_path):
+    """Test that the agent team can communicate with the planner model."""
+    # Load the properties from the file
+    agent_props = None
+    with open(agent_model_props_path, 'r') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if row['AGENT_ROLE'] == agent_role:
+                agent_props = row
+                break
+    
+    assert agent_props is not None, f"No properties found for {agent_role}"
+    
+    # Mock the requests.post method
+    with mock.patch('requests.post') as mock_post:
+        # Set up the mock to return a successful response
+        mock_post.return_value = MockResponse({
+            'response': 'This is a test response.'
+        })
+        
+        # Test the model communication
+        response = test_agent_team._call_model(
+            agent_role=agent_role,
+            prompt="This is a test prompt.",
+            agent_props=agent_props
+        )
+        
+        # Verify the response
+        assert isinstance(response, str), "Response should be a string"
+        assert response == 'This is a test response.', "Response does not match expected value"
+        
+        # Verify that requests.post was called with the correct arguments
+        mock_post.assert_called_once()
+        
+        # Extract the args and kwargs from the call
+        args, kwargs = mock_post.call_args
+        
+        # Verify that the URL is correct
+        url = args[0] if args else kwargs.get('url')
+        assert url is not None, "URL not found in requests.post call"
+        
+        # Verify that the data includes a prompt
+        data = kwargs.get('json')
+        assert data is not None, "JSON data not found in requests.post call"
+        assert 'prompt' in data, "Prompt not found in JSON data"
+        assert data['prompt'] == "This is a test prompt.", "Prompt does not match expected value"
+
+
+# Test with actual model communication if the environment allows it
+# This test is marked as 'optional' because it requires access to the actual model
+@pytest.mark.optional
+@pytest.mark.parametrize("agent_role", ["PLANNER", "MANAGER", "ACTOR", "EVALUATOR"])
+def test_actual_model_communication(test_agent_team, agent_role, agent_model_props_path):
+    """Test that the agent team can communicate with the actual model."""
+    # Skip this test if we're in a CI environment or don't have access to the model
+    if os.environ.get('CI') == 'true' or not os.environ.get('TEST_ACTUAL_MODEL'):
+        pytest.skip("Skipping actual model communication test in CI or without TEST_ACTUAL_MODEL=true")
+    
+    # Load the properties from the file
+    agent_props = None
+    with open(agent_model_props_path, 'r') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if row['AGENT_ROLE'] == agent_role:
+                agent_props = row
+                break
+    
+    assert agent_props is not None, f"No properties found for {agent_role}"
+    
+    # Test the model communication with a very short prompt
+    response = test_agent_team._call_model(
+        agent_role=agent_role,
+        prompt=f"This is a test prompt for {agent_role}. Please respond with a single word: 'test'.",
+        agent_props=agent_props
+    )
+    
+    # Verify that we got some kind of response and not an error
+    assert isinstance(response, str), "Response should be a string"
+    assert not response.startswith("Error:"), f"Response indicates an error: {response}"
+    
+    # The response should have at least some length
+    assert len(response) > 0, "Response is empty"


### PR DESCRIPTION
## Summary
- Create pytest framework for testing
- Add unit tests for all agent roles (PLANNER, MANAGER, ACTOR, EVALUATOR)
- Test model communication with mocks and optional actual model tests
- Add testing documentation to README
- Update dependencies in setup.py and requirements.txt

## Test plan
- Run  to verify all tests pass with mocks
- To test with actual models, set environment variable TEST_ACTUAL_MODEL=true
- Tests can be run with  to get coverage information

Fixes #2